### PR TITLE
feat: add pre/post-implementation critic layer

### DIFF
--- a/.ab-method/core/create-roadmap.md
+++ b/.ab-method/core/create-roadmap.md
@@ -107,6 +107,22 @@ Rules for the graph:
 Set the roadmap **Status** flow: `Planning → Ready → In dev → Completed`.
 It becomes `Ready` once every task is `✅ planned`.
 
+### 2.5 Pre-implementation Critique — invoke the `critique-plan` skill on the DAG
+
+With the `roadmap.md` draft written, run the **task graph** past the domain model before handing off
+per-task planning. **Invoke the `critique-plan` skill** — it spins up a read-only domain critic that
+challenges the *decomposition* (not any single task's internals) against `UBIQUITOUS_LANGUAGE.md`,
+`CONTEXT.md`, and ADRs.
+
+At the roadmap level the pushbacks it looks for are graph-shaped: a `depends-on` edge that crosses a
+documented seam the wrong way, two "independent" tasks that actually share a domain concept, a task
+mis-scoped as an epic or a single mission, or a slug that reinvents a canonical term. It is **advisory and
+opt-in-silent** — a sound graph gets "No objections." Resolve any real pushback with the user (re-draw an
+edge, re-scope or rename a task, move work to the right context) and update `roadmap.md` before Step 3.
+
+The skill owns the critique logic; it reads `.ab-method/structure/index.yaml` for where the domain model
+lives.
+
 ### 3. Plan Each Task — in dependency order, in its own session
 
 Tasks are planned **foundational-first**: a task is only planned after

--- a/.ab-method/core/create-task-from-handoff.md
+++ b/.ab-method/core/create-task-from-handoff.md
@@ -38,7 +38,9 @@ From here the work is identical to `create-task` starting at its Step 2. Follow 
 - Identify task type and complexity.
 - Create the task folder and slim `progress-tracker.md`.
 - Define all missions upfront.
-- Confirm with the user, then run each mission through the `tdd` skill.
+- Run `critique-plan` on the drafted missions (create-task § 7.5) — the pre-implementation domain critic.
+- Confirm with the user, then run each mission through the `tdd` skill, and `review-implementation` after
+  the last one (create-task § 9) — the post-implementation review.
 
 ### 5. Retire the handoff
 

--- a/.ab-method/core/create-task.md
+++ b/.ab-method/core/create-task.md
@@ -287,9 +287,24 @@ Append the tag to the mission line in `progress-tracker.md`:
 - A mission must never depend on a sibling in its own group. When in doubt, leave it sequential.
 - Number groups in execution order: `pp-1`, `pp-2`, ...
 
+### 7.5 Pre-implementation Critique — ALWAYS invoke the `critique-plan` skill
+
+Before asking the user to validate, run the drafted mission list past the domain model. **Invoke the
+`critique-plan` skill** on every `/create-task` invocation — it spins up a read-only domain critic that
+challenges the missions against `UBIQUITOUS_LANGUAGE.md`, `CONTEXT.md`, ADRs, and the architecture docs.
+
+It is **advisory and opt-in-silent**: it pushes back only on genuine conflicts (terminology drift, wrong
+bounded context, an ADR contradiction, a mission that reinvents a named concept). A sound plan gets a
+one-line "No objections" — that is the common outcome, so don't treat its silence as a failure to find
+something. When it does push back, resolve each with the user (amend the mission, or dismiss with a
+load-bearing reason the skill may capture as an ADR), then update the tracker to match before Step 8.
+
+The skill owns the critique logic — do not duplicate it here. It reads
+`.ab-method/structure/index.yaml` for where the domain model lives.
+
 ### 8. Confirm with User
 
-Show the progress tracker with all missions defined and ask:
+Show the progress tracker with all missions defined (reflecting any changes from Step 7.5) and ask:
 "Task created with status 'Brainstormed'. Missions: [list, one line each]. Ready to validate and start Mission 1?"
 
 When the user confirms, update status to 'Validated' and proceed to Step 9.
@@ -342,7 +357,20 @@ After the skill is loaded:
 
 8. **Prompt the user** before moving to the next mission: "Mission N completed. Ready to start Mission N+1?"
 
-When all missions are done, set task status to `Completed`.
+When all missions are done, run the **post-implementation review** (below), then set task status to `Completed`.
+
+#### Post-implementation review — invoke the `review-implementation` skill
+
+Once the last mission is green, **invoke the `review-implementation` skill** on the task's diff (the
+cohesive change across all missions). It spins up three read-only critics in parallel —
+`cleaner-architecture`, `slop-defender`, `reusability-inspector` — that push back only on real issues
+(shallow modules the change introduced, AI code-slop, reinvented logic). A clean diff produces no
+findings; that's the normal case.
+
+`/create-task` is interactive, so run the skill in **interactive mode**: it presents findings grouped by
+lens (each marked `safe-fix` / `needs-judgment`) and you apply what the user approves, keeping tests
+green. (Autonomous runs via `/start-task` instead auto-apply safe fixes and write a `review.md` — that's
+the skill's other mode.) The skill owns the review logic; don't duplicate it here.
 
 #### Parallel group execution (`pp-x` missions)
 

--- a/.ab-method/core/extend-task.md
+++ b/.ab-method/core/extend-task.md
@@ -59,6 +59,15 @@ Check `docs/roadmaps/*/roadmap.md` (the `relationships` map in `.ab-method/struc
 
 This is what lets a later `/start-roadmap` re-run notice the new work. Extending a task that others depend on does **not** auto-reopen those downstream tasks — their own missions are still done. If the tweak actually changes what a downstream task needs, extend that task too; `/start-roadmap` will then run both in dependency order.
 
+### 5.5 Pre-implementation Critique — invoke the `critique-plan` skill on the NEW missions
+
+Before confirming, run the newly drafted missions past the domain model — same discipline as
+`/create-task` § 7.5. **Invoke the `critique-plan` skill** scoped to the *new* missions (with the
+existing ones as context): a read-only domain critic pushes back only on genuine conflicts (terminology
+drift, wrong context, an ADR contradiction, a reinvented concept). Advisory and silent when the
+additions are sound. Resolve any real pushback (amend a mission, or dismiss with a load-bearing reason
+that may become an ADR) and update the tracker before Step 6.
+
 ### 6. Confirm with User
 "Added [N] missions. Ready to start Mission X?"
 

--- a/.ab-method/core/mastermind.md
+++ b/.ab-method/core/mastermind.md
@@ -60,6 +60,8 @@ Common routes:
 | Run an existing task autonomously to completion | `start-task` |
 | Run a whole roadmap of tasks in dependency order | `start-roadmap` |
 | Continue a tangent that got parked mid-grill | `create-task-from-handoff` |
+| Stress-test a plan against the domain model (standalone) | `critique-plan` skill |
+| Review a completed diff for architecture / slop / reuse (standalone) | `review-implementation` skill |
 | Understand the codebase (arch / domain) | `analyze-project` / `analyze-frontend` / `analyze-backend` |
 | Refresh architecture docs after big changes | `update-architecture` |
 | Backfill tests for code written without them | `test-mission` |

--- a/.ab-method/core/resume-task.md
+++ b/.ab-method/core/resume-task.md
@@ -69,7 +69,18 @@ Append a tight technical summary to the progress tracker (same format as `create
 
 For a parallel group: append one summary block per mission, mark the whole group complete, and prompt once per group — "Missions N–M (`[pp-x]`) completed in parallel. Ready to continue with Mission M+1?"
 
-When all missions are done, set task status to `Completed`.
+When all missions are done, run the **post-implementation review**, then set task status to `Completed`.
+
+### 8. Post-Implementation Review — invoke the `review-implementation` skill
+
+Once the last mission is complete, **invoke the `review-implementation` skill** on the task's diff (the
+cohesive change across all its missions). Three read-only critics — `cleaner-architecture`,
+`slop-defender`, `reusability-inspector` — push back only on real issues; a clean diff yields nothing.
+
+`/resume-task` keeps you in the loop, so run it in **interactive mode**: it presents findings grouped by
+lens (each marked `safe-fix` / `needs-judgment`) and you apply what you approve, keeping tests green.
+(The autonomous `/start-task` variant instead auto-applies safe fixes and writes a `review.md`.) The
+skill owns the review logic; don't duplicate it here. Then set status to `Completed`.
 
 ## Remember
 - The progress tracker carries everything you need; there are no mission docs by design

--- a/.ab-method/core/start-roadmap.md
+++ b/.ab-method/core/start-roadmap.md
@@ -161,6 +161,18 @@ nested.
 - On green completion, set `status:` to `done` in `roadmap.md` and check
   off its line.
 
+**Post-implementation review is inherited per task.** Because each task
+runs by `start-task` rules, its Step 5b runs the `review-implementation`
+skill on that task's diff — three read-only critics
+(`cleaner-architecture`, `slop-defender`, `reusability-inspector`), safe
+fixes auto-applied and everything written to that task's
+`docs/tasks/<slug>/review.md`. The review's critic subagents follow the
+**same nesting rule as the mission subagents**: on **Claude** the
+task-subagent spawns them (nested); on **Codex** the parent spawns them
+at its own level (flat). Nothing extra to wire here — it comes for free
+with running each task as a `start-task`. The roadmap orchestrator only
+collects the resulting `review.md` locations for the final report.
+
 #### Running independent tasks concurrently
 
 - **Sequential mode (default):** run eligible tasks one after another in
@@ -217,7 +229,11 @@ Roadmap completed: <Name>
 Tasks run: task-a, (task-b ∥ task-c), task-d
 Commits: <n> across <m> tasks
 Tests: <command> green
+Reviews: docs/tasks/<slug>/review.md per task — <total> safe fixes applied, <total> open for you
 ```
+
+List each task's `review.md` with its open-finding count so the afk user
+can jump straight to the ones that want their judgment.
 
 If execution stopped at an unplanned frontier rather than finishing,
 report what ran and what still needs planning:
@@ -255,7 +271,8 @@ Same discipline as `/start-task`, one level up:
 - **Executor, not producer** — never define or reshape tasks; run what
   `/create-roadmap` + `/create-task` planned
 - **Each task runs by `start-task` rules** — same subagent-per-mission,
-  tdd, commit trail
+  tdd, commit trail, and post-implementation `review-implementation` pass
+  (safe fixes applied, `review.md` written per task)
 - **Execution shape is runtime-adaptive** — on **Claude Code, nest by
   default** (task-subagent → mission-subagents) for per-task context
   isolation; on **Codex** stay flat (parent → mission-subagents) because

--- a/.ab-method/core/start-task.md
+++ b/.ab-method/core/start-task.md
@@ -94,6 +94,28 @@ Follow **Parallel group execution** in `create-task.md` § 9 — all uncompleted
 
 Then move straight to the next mission.
 
+### 5b. Post-Implementation Review — invoke the `review-implementation` skill (autonomous mode)
+
+Once every mission is green and committed, run the **post-implementation review** on the task's diff
+(the cohesive change across all missions — its commit range). **Invoke the `review-implementation`
+skill in autonomous mode.** It spins up three read-only critics in parallel — `cleaner-architecture`,
+`slop-defender`, `reusability-inspector` — that push back only on real issues (shallow modules the change
+introduced, AI code-slop, reinvented logic). A clean diff produces no findings; that's the normal case.
+
+Because this is an afk run, the skill:
+1. **Auto-applies only `safe-fix` findings** — mechanical, test-covered, no behavior/interface change.
+   The orchestrator (you) applies them one at a time and **re-runs the test suite after each**; a fix that
+   goes red is reverted and downgraded to an open finding. Red is still a stop sign for the *task's own*
+   work, but a reverted review fix is not a failure — it just stays open for the user.
+2. **Commits kept safe fixes** as one `refactor(<task-name>): post-review cleanup` (repo convention). No
+   fixes → no commit.
+3. **Writes `docs/tasks/<task>/review.md`** — every finding, applied (✅) or open (⬜ needs judgment) —
+   next to `progress-tracker.md`, so the user can read exactly what happened and what still wants their
+   call. It writes this file even when all lenses are clean, so the user knows the review ran.
+
+The skill never prompts — anything uncertain stays open rather than being changed. It owns the review
+logic and the `review.md` format; don't duplicate them here.
+
 ### 6. On Full Completion
 
 Set the task status to `Completed` in the tracker (include it in the final mission's commit, or a final `chore` commit if needed). Report:
@@ -103,6 +125,7 @@ Task completed: <Task Name>
 Missions run: 3, 4-5 [pp-1], 6
 Commits: <n> (<short hashes>)
 Tests: <command> green
+Review: docs/tasks/<task>/review.md — <k> safe fixes applied, <m> open for you
 ```
 
 ### 7. On Failure — Stop Loudly, Never Plough On
@@ -120,6 +143,7 @@ If a mission subagent fails, tests stay red, or a merge conflict can't be resolv
 - **Executor, not producer** — `/start-task` does not define or reshape missions; that's `/create-task` and `/extend-task`. The vagueness gate is the only place grilling happens, and only before the run
 - **Every mission in a subagent** — the subagent runs tdd and updates the tracker itself; the parent verifies and commits
 - **Commit after each mission** — green tests are the gate; one commit per mission, one per `[pp-x]` group
+- **Review before completion** — after the last green mission, `review-implementation` runs in autonomous mode: safe fixes auto-applied (tests-green-gated, own commit), everything written to `review.md` for the afk user; open findings are never silently changed
 - **Red stops the run** — exactly like a `/goal` feedback loop: a failing check takes priority over progress
 - **Tracker is the single source of truth** — same as every task workflow; subagent updates for sequential missions, parent updates for parallel groups
 

--- a/.ab-method/structure/index.yaml
+++ b/.ab-method/structure/index.yaml
@@ -33,6 +33,10 @@ project_structure:
       todo-table-creation:
         files:
           - progress-tracker.md
+          - review.md             # post-implementation review (review-implementation
+                                  # skill); written by autonomous runs (start-task /
+                                  # start-roadmap): safe fixes marked applied, the rest
+                                  # left open for the user. Absent until a review runs.
         folders:
           - sub-agents-outputs/   # only created when a subagent runs
 
@@ -78,21 +82,26 @@ workflow_outputs:
   domain-model:
     - CONTEXT.md          # refined inline during the grilling session
     - docs/adr/           # ADRs created lazily
-  create-task: docs/tasks/[task-name]/progress-tracker.md
+  create-task: docs/tasks/[task-name]/progress-tracker.md   # runs critique-plan (pre-impl, advisory) before validating missions, and review-implementation (post-impl, interactive) after the last mission
+  critique-plan: []   # pre-implementation critic; read-only, surfaces domain-model pushbacks only (may prompt an ADR under docs/adr/ on a load-bearing dismissal). Invoked by create-task / create-roadmap, or standalone
+  review-implementation: docs/tasks/[task-name]/review.md   # post-implementation review; three critics on the task diff. Writes review.md on autonomous runs; interactive runs present findings instead
   create-task-from-handoff: docs/tasks/[task-name]/progress-tracker.md   # reads docs/handoffs/[slug].md, deletes it once the task exists
   extend-task: docs/tasks/[task-name]/progress-tracker.md
   resume-task: docs/tasks/[task-name]/progress-tracker.md
-  start-task: docs/tasks/[task-name]/progress-tracker.md   # autonomous run; mission subagents update the tracker, parent commits per mission
   handoff: docs/handoffs/[slug].md   # `handoff` skill; falls back to OS temp dir outside an AB Method project
   create-goal:
     - docs/goals/[goal-name]/goal.md
     - docs/goals/[goal-name]/progress-tracker.md
   extend-goal:
     - docs/goals/[goal-name]/goal.md   # updated in place; progress-tracker.md carries forward
-  create-roadmap: docs/roadmaps/[roadmap-name]/roadmap.md   # DAG of tasks; per-task create-task prompts emitted in dep order
+  create-roadmap: docs/roadmaps/[roadmap-name]/roadmap.md   # DAG of tasks; runs critique-plan on the graph (pre-impl, advisory) before emitting per-task create-task prompts in dep order
+  start-task:
+    - docs/tasks/[task-name]/progress-tracker.md   # autonomous run; mission subagents update the tracker, parent commits per mission
+    - docs/tasks/[task-name]/review.md   # post-impl review-implementation pass after the last mission: safe fixes applied, open findings recorded
   start-roadmap:
     - docs/roadmaps/[roadmap-name]/roadmap.md   # statuses updated as tasks run; verifies plans exist before executing
     - docs/tasks/[task-name]/progress-tracker.md   # each task executes like start-task (subagent per mission, commit per green mission)
+    - docs/tasks/[task-name]/review.md   # each task's post-impl review (inherited from start-task rules)
 
 # How the workflows and their artifacts reference each other. Any workflow
 # reads this file first, so this map is how they "know about each other"

--- a/.agents/skills/critique-plan/SKILL.md
+++ b/.agents/skills/critique-plan/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: critique-plan
+description: Pre-implementation critic. Spins up a read-only domain critic that challenges a drafted plan — a task's missions or a roadmap's task graph — against the ubiquitous language, CONTEXT.md, and ADRs, and pushes back ONLY on genuine conflicts. Silent when the plan is sound. Use before implementing (from create-task / create-roadmap) or standalone to stress-test a plan against the project's domain model.
+---
+
+# Critique Plan (pre-implementation)
+
+Stress-test a **drafted plan** against the project's domain model **before** any code is written. This
+skill produces **pushbacks, not suggestions** — it never gold-plates a plan that is already sound.
+
+> **Silence is the expected outcome.** A plan that speaks the canonical language and respects the
+> documented decisions gets a one-line "No objections." Do not manufacture concerns to look thorough.
+
+**ALWAYS check `.ab-method/structure/index.yaml` FIRST** for where the domain model lives — paths are
+user-configurable.
+
+"The plan" is the drafted **mission list** (from create-task), the **task DAG** (from create-roadmap), or
+whatever the user pastes in (standalone).
+
+## Process
+
+### 1. Load the domain model
+
+Read only what exists; skip missing files silently (don't flag them or offer to create them):
+`UBIQUITOUS_LANGUAGE.md`, `CONTEXT.md` (or `CONTEXT-MAP.md` + each `src/<context>/CONTEXT.md`),
+`docs/adr/`, and `docs/architecture/*`.
+
+### 2. Spin up ONE read-only domain critic (subagent)
+
+Spawn a single subagent — `domain-critic` — with the plan verbatim, the files from Step 1, and the rule
+that it is **read-only**: it returns pushbacks as text and edits nothing. Isolating it keeps the critique
+out of the planning context. Its brief:
+
+**Fire ONLY on a genuine conflict**, one of:
+- **Terminology drift** — the plan names a concept differently from the glossary/`CONTEXT.md`, or reuses
+  a canonical term for a new meaning.
+- **Wrong bounded context** — work placed in the wrong context, or a unit that straddles a documented
+  boundary.
+- **Contradicts an ADR** — reverses a recorded decision *and* the friction is real enough to reopen it.
+  Cite `ADR-NNNN`.
+- **Bad graph seam** (roadmap) — a `depends-on` edge crosses a seam the wrong way, two "independent"
+  tasks share a domain concept, or a task is mis-scoped (an epic, or a single mission dressed as a task).
+- **Reinvents a named concept** — introduces a new abstraction for something the domain model names.
+
+For each, return **What** (the mission/task/decision), **Conflicts with** (the exact term / `CONTEXT.md`
+section / `ADR-NNNN`), **Why it matters** (concrete cost, not taste), **Suggested resolution**.
+
+> Example pushback: *"Mission 3 calls it `archiveOrder`, but the glossary defines archiving as retention
+> only — this mission also stops billing, which is **Cancellation**. Rename to `cancelOrder` so the code
+> matches the domain, or the two concepts will blur across the codebase."*
+
+**Out of scope for this critic:** implementation quality, performance, tests, code style, "you could
+also…" ideas — anything not anchored in the domain model. Those belong to the post-implementation
+[review-implementation](../review-implementation/SKILL.md) skill. With nothing anchored, the critic
+returns exactly: `No objections — the plan is consistent with the domain model.`
+
+### 3. Surface pushbacks — advisory, never blocking
+
+Bring the pushbacks back into the planning session. The user resolves each their way:
+- **Accept** → amend the plan (rename, re-scope, fix the edge, move contexts) right there.
+- **Dismiss** → drop it. If the dismissal rests on a **load-bearing reason** a future planner would need
+  in order not to re-raise it, offer to record an ADR ([../domain-model/ADR-FORMAT.md](../domain-model/ADR-FORMAT.md)).
+  Skip ephemeral ("not now") and self-evident reasons.
+
+When a resolution sharpens a term, update `CONTEXT.md` inline
+([../domain-model/CONTEXT-FORMAT.md](../domain-model/CONTEXT-FORMAT.md)) — same discipline as `/domain-model`.
+
+If the critic returned "No objections," say so in one line and move on. Don't pad it.
+
+`/domain-model` is a full interactive re-grill of the design; `critique-plan` is a **single-pass,
+silent-by-default gate** — one critic, real conflicts only, then straight back to the workflow.

--- a/.agents/skills/review-implementation/ARCHITECTURE.md
+++ b/.agents/skills/review-implementation/ARCHITECTURE.md
@@ -1,0 +1,55 @@
+# Lens: cleaner-architecture
+
+You are the `cleaner-architecture` critic. You review **only this task's diff** for **shallow modules**
+that the change introduced or worsened, and propose **deepening** them. You are read-only: return
+findings, edit nothing.
+
+## Vocabulary — use it exactly
+
+This lens reuses the language already defined for this repo. Read these before you start and use their
+terms (don't drift into "component / service / boundary"):
+
+- [../improve-codebase-architecture/LANGUAGE.md](../improve-codebase-architecture/LANGUAGE.md) —
+  **module, interface, implementation, depth, seam, adapter, leverage, locality**, the **deletion test**.
+- [../improve-codebase-architecture/DEEPENING.md](../improve-codebase-architecture/DEEPENING.md) — how to
+  deepen a cluster safely given its dependency category (in-process / local-substitutable / remote-owned
+  / true-external), and seam discipline (**one adapter = hypothetical seam; two = real**).
+
+Speak the **domain** in `CONTEXT.md` terms and the **architecture** in `LANGUAGE.md` terms — "the Order
+intake module," not "the FooBarHandler."
+
+## What to look for — in the diff only
+
+- **New shallow modules** — a function/class/file the diff added whose interface is nearly as complex as
+  its implementation. Apply the **deletion test**: if you deleted it, would complexity vanish (it was a
+  pass-through) or reappear concentrated across N callers (it earned its keep)? "Vanishes" = shallow.
+- **Pure functions extracted only for testability**, where the real bugs live in *how they're called* —
+  the extraction bought a testable unit but scattered **locality**.
+- **Tight coupling leaking across a seam** the diff created — callers that must know the implementation's
+  internals to use it.
+- **Single-adapter "seams"** — an interface/port the diff introduced with exactly one implementation and
+  no second one in sight. That's indirection, not a seam.
+- **Untested surface** the diff added that is hard to test *through its current interface* — a sign the
+  interface is in the wrong place.
+
+## What NOT to flag
+
+- Pre-existing shallowness the diff didn't touch (that's `/improve-codebase-architecture`'s job, not this
+  review's).
+- Anything an ADR already settled.
+- Depth for depth's sake — if the current shape is already deep enough, say nothing.
+- Style, naming aesthetics, perf — not this lens (naming-as-slop belongs to `slop-defender`).
+
+## Output
+
+For each real finding:
+- **Files** — the modules involved.
+- **Problem** — why it's shallow / where locality or leverage is lost, in `LANGUAGE.md` terms.
+- **Deletion-test result** — vanishes (shallow) vs concentrates (keep).
+- **Suggested deepening** — plain English: what merges behind what interface, what sits at the seam,
+  which dependency category it is (so the tester knows adapter vs stand-in vs direct).
+- **safe-fix vs needs-judgment** — inlining one shallow pass-through into its single caller with tests
+  green is often `safe-fix`; merging several modules behind a new seam is `needs-judgment`.
+
+If the diff introduced no shallowness worth deepening, return exactly:
+`cleaner-architecture: no findings.`

--- a/.agents/skills/review-implementation/REUSE.md
+++ b/.agents/skills/review-implementation/REUSE.md
@@ -1,0 +1,55 @@
+# Lens: reusability-inspector
+
+You are the `reusability-inspector` critic. You catch **reinvention and duplication** in **this task's
+diff** — logic the diff wrote fresh that the codebase already provides, or logic the diff repeats within
+itself. You are read-only: return findings, edit nothing.
+
+Your edge over the other lenses: you must **look outward at the existing codebase**, not just the diff.
+A duplication finding is only credible once you've found the thing being duplicated.
+
+## What to look for
+
+- **Reinvented utilities** — the diff hand-rolls something the repo already has: date formatting,
+  slugify, deep-clone, retry, validation, HTTP wrappers, a money/tax calculation. Search for an existing
+  equivalent before flagging, and name it.
+- **Duplicated domain logic** — the diff re-implements a rule that lives in a canonical module named in
+  `CONTEXT.md` (e.g. a second place that decides when an *Order* is *cancellable*). Domain rules must
+  live in one place.
+- **Ignored existing patterns** — the diff builds a route / component / query in a way that departs from
+  `frontend-patterns.md` / `backend-patterns.md` when a documented pattern (or a near-identical sibling
+  in the codebase) already fits. Point at the sibling.
+- **Internal copy-paste** — the same block repeated across files or missions in the diff, begging to be a
+  shared function or a loop.
+- **Reinvented types** — a new interface/DTO that restates an existing type instead of importing or
+  extending it, risking the two drifting apart.
+
+## How to verify before flagging
+
+1. Grep/search the codebase for the capability (by likely name, by signature shape, by domain term from
+   `CONTEXT.md`).
+2. Confirm the existing thing has **the same semantics**, not just a similar name — a near-match with
+   different edge behavior is *not* a duplication; note that distinction if it's subtle.
+3. Only then report, naming the exact existing module/function/type to reuse.
+
+## What NOT to flag
+
+- "Duplication" where the two pieces have genuinely different semantics or evolve independently (the
+  wrong abstraction is more expensive than a little duplication — say so if you see it being forced).
+- Reuse an ADR explicitly decided against.
+- Trivial two-line similarities that a shared helper would only obscure.
+- Cross-context reuse that would couple two bounded contexts the domain model keeps apart — that coupling
+  is worse than the duplication.
+
+## Output
+
+For each real finding:
+- **Files** — the reinventing code in the diff.
+- **Existing thing to reuse** — exact path + symbol (`src/lib/money.ts → calculateTax`).
+- **Why it matters** — the concrete cost of two copies (they will drift; a fix must be made twice; the
+  domain rule now lives in two places).
+- **Suggested change** — import/extend/call the existing module; or extract the internal copy-paste once.
+- **safe-fix vs needs-judgment** — replacing a fresh copy with a call to an existing util of **identical**
+  semantics, tests green, is `safe-fix`. Anything where the semantics might differ, or that reshapes an
+  interface, is `needs-judgment`.
+
+If the diff reinvented nothing, return exactly: `reusability-inspector: no findings.`

--- a/.agents/skills/review-implementation/SKILL.md
+++ b/.agents/skills/review-implementation/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: review-implementation
+description: Post-implementation review. Spins up three read-only critics on a completed task's diff — cleaner-architecture, slop-defender, reusability-inspector — that push back ONLY on real issues. Autonomous runs apply safe fixes (tests-green-gated) and write everything to review.md next to progress-tracker.md; interactive runs present findings to pick. Use after a task's missions are done (from start-task / start-roadmap / create-task) or standalone on a diff.
+---
+
+# Review Implementation (post-implementation)
+
+Review a **completed task's diff** through three lenses, each a read-only critic subagent. The
+counterpart to [../critique-plan/SKILL.md](../critique-plan/SKILL.md): that guards the plan *before*
+coding; this guards the result *after*.
+
+> **Silence is the default output.** A clean diff produces no findings — that is the normal case. A
+> finding survives only if a senior engineer, looking at this diff, would actually make the change. State
+> each as a concrete cost, not a preference. Never invent refactors to look thorough.
+
+**ALWAYS check `.ab-method/structure/index.yaml` FIRST** for paths (task location, domain model,
+`review.md`). Review **only what this task changed** — the cohesive diff across its missions (`git diff`
+for the commit range). This is not a whole-codebase audit; that's `/improve-codebase-architecture`.
+
+## Process
+
+### 1. Gather diff + context
+
+The changed files and their `git diff`, plus (read only what exists): `UBIQUITOUS_LANGUAGE.md` /
+`CONTEXT.md` (canonical terms, spotting reinvented concepts), `docs/architecture/*` (the documented way
+things are built here), `docs/adr/` (don't propose what an ADR settled).
+
+### 2. Spin up THREE read-only critics — in parallel
+
+Spawn three subagents **in one batch**, named exactly:
+
+| Agent | Lens | Brief |
+|---|---|---|
+| `cleaner-architecture` | depth / deepening | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| `slop-defender` | AI code-slop | [SLOP.md](SLOP.md) |
+| `reusability-inspector` | duplication / reuse | [REUSE.md](REUSE.md) |
+
+Each is **read-only** — analyses the diff, returns a findings list (often empty), edits nothing. Seed
+each with the diff + context + its lens file. On **Codex** (`spawn_agent` is one level deep) spawn them
+at the orchestrator's own level — flat; on **Claude** they may nest. Flat works on both.
+
+### 3. Collect + classify
+
+Merge the lists. Drop anything that's a preference (not a concrete cost), an ADR already settled, or a
+design change bigger than this task (note it open, don't act). Classify each survivor:
+
+- **`safe-fix`** — confirmed, mechanical, **covered by existing tests**, **no interface/behavior change**
+  (delete dead code, inline a pass-through, drop a redundant comment, call an existing util of identical
+  semantics).
+- **`needs-judgment`** — real but design-level, risky, behavior/interface-affecting, or not test-covered.
+
+### 4. Act — by mode
+
+**Interactive** (manual create-task tail, or standalone): present findings grouped by lens, each marked
+`safe-fix`/`needs-judgment`; apply what the user approves; run tests; report.
+
+**Autonomous** (`start-task` / `start-roadmap` — afk): the **orchestrator** (never the parallel critics)
+applies fixes, so there are no concurrent writes:
+1. For each `safe-fix`: apply it, **re-run the test suite** (command from `tech-stack.md`). Green → keep.
+   Red → **revert it**, downgrade to `needs-judgment` with a note (`attempted, reverted — broke <test>`).
+2. Commit kept fixes as one `refactor(<task>): post-review cleanup` (repo convention). Nothing kept → no commit.
+3. **Write `docs/tasks/<task>/review.md`** (below) — every finding, applied or open. Never prompt;
+   anything uncertain stays open rather than being changed.
+
+### 5. `review.md` format
+
+Written next to `progress-tracker.md`. Always write it in autonomous mode — even when clean — so the afk
+user knows the review ran.
+
+```markdown
+# Post-Implementation Review: <Task Name>
+**Reviewed**: YYYY-MM-DD   **Scope**: missions <a–z> / commit <range>
+
+## Applied — safe fixes ✅ (commit <hash>)
+- [slop-defender] removed pass-through wrapper `fooProxy` — src/foo.ts
+- [cleaner-architecture] inlined shallow `formatName` into its one caller — src/user.ts
+
+## Open — need your judgment ⬜
+### [reusability-inspector] duplicates `paymentService.calculateTax`
+- **Files**: src/checkout/tax.ts
+- **Why it matters**: two tax formulas will drift; a rate change must be made twice.
+- **Suggested change**: call the existing `paymentService.calculateTax` instead.
+
+## Clean lenses
+- slop-defender: no further findings
+```
+
+If all three lenses are clean and nothing was applied, the whole body is one line:
+`All three lenses clean — no findings.`

--- a/.agents/skills/review-implementation/SLOP.md
+++ b/.agents/skills/review-implementation/SLOP.md
@@ -1,0 +1,55 @@
+# Lens: slop-defender
+
+You are the `slop-defender` critic. You hunt **AI code-slop** in **this task's diff** — the reflexive
+over-production that models add when left unsupervised: abstraction nothing asked for, ceremony that
+carries no weight, comments that restate the obvious. You are read-only: return findings, edit nothing.
+
+> This is the *code* counterpart of prose "slop." The test for every item below is the **deletion test**
+> (see [../improve-codebase-architecture/LANGUAGE.md](../improve-codebase-architecture/LANGUAGE.md)):
+> delete it — does anything real break, or does the code get simpler and just as correct? If deleting it
+> loses nothing, it's slop.
+
+## The slop checklist — flag only what the diff actually added
+
+- **Speculative generality** — parameters, options, generics, or extension points with exactly one
+  caller and no second one in sight. Built for an imagined future, not the requirement. (YAGNI.)
+- **Premature abstraction** — a base class / interface / factory / strategy introduced for a single
+  concrete case. One implementation is not a seam (echoes the architecture lens; flag whichever fits).
+- **Pass-through wrappers** — a function/method/module that only forwards to another with no added
+  behavior. `getName(u) { return u.name }`, `fooProxy` that calls `foo`.
+- **Dead / unreachable code** — added-but-unused helpers, `if (false)` branches, exports nothing imports,
+  handling for cases the callers can't produce.
+- **Defensive checks for impossible states** — null guards on values the type system already guarantees,
+  try/catch that swallows and rethrows, validation of inputs a caller has already validated.
+- **Comments that restate the code** — `// increment i` above `i++`, docstrings that echo the signature,
+  section-divider banners. Keep comments that explain *why*; cut the ones that narrate *what*.
+- **Needless configuration** — flags, env vars, or config keys with a single value that never varies;
+  "customizable" knobs nothing turns.
+- **Over-verbose naming / ceremony** — `AbstractBaseUserServiceFactoryImpl`, wrapper types that alias a
+  primitive for no invariant, getters/setters over plain fields with no logic.
+- **Redundant tests** — tests asserting the language/framework works, or several tests covering the exact
+  same path with no distinct behavior; and their inverse — a big new surface with **no** test at all.
+- **Copy-pasted boilerplate** the diff duplicated instead of looping/reusing (hand hard duplication to
+  `reusability-inspector`; flag the *ceremony* kind here).
+
+## What NOT to flag
+
+- Slop that predates this diff and wasn't touched.
+- Genuine defensiveness at a real trust boundary (untrusted input, external API, concurrency) — that's
+  not slop, it's necessary.
+- A comment that explains a non-obvious *why*, a hack, or a gotcha — keep it.
+- Anything an ADR blessed.
+- Deep abstractions that already earn their keep across multiple callers.
+
+## Output
+
+For each real finding:
+- **Files + location** — where the slop is.
+- **What kind** — name the checklist item.
+- **Deletion-test result** — what is lost by removing it (nothing = confirmed slop).
+- **Suggested change** — delete / inline / collapse.
+- **safe-fix vs needs-judgment** — deleting dead code, inlining a pure pass-through, or cutting a
+  restate-the-code comment with tests green is usually `safe-fix`. Removing an abstraction other code
+  leans on, or anything you're unsure the tests cover, is `needs-judgment`.
+
+If the diff added no slop, return exactly: `slop-defender: no findings.`

--- a/.claude/commands/create-roadmap.md
+++ b/.claude/commands/create-roadmap.md
@@ -18,7 +18,8 @@ It will:
 1. **Always check `.ab-method/structure/index.yaml` first** for paths and the `relationships` map.
 2. **Grill the idea once** (`grill-with-docs`, aimed at decomposition) to identify discrete tasks and their `depends-on` edges.
 3. Write `docs/roadmaps/<name>/roadmap.md` — the DAG of tasks (coarse scope each, no missions), plus per-task `plan:` / `status:` fields. This is the roadmap-level source of truth.
-4. Emit a ready-to-paste `/create-task` prompt per task, **in dependency order** (foundational first), each seeded with the roadmap objective + upstream deps.
+4. **Run `critique-plan`** on the task graph — a read-only domain critic that pushes back only on genuine decomposition conflicts (wrong seams, mis-scoped tasks, boundary violations) against the domain model. Advisory; silent when the graph is sound.
+5. Emit a ready-to-paste `/create-task` prompt per task, **in dependency order** (foundational first), each seeded with the roadmap objective + upstream deps.
    - **Recommended:** run each in a fresh session (isolated, deep grilling).
    - **Discouraged:** plan inline in this session — it warns you about context bloat first.
 

--- a/.claude/commands/create-task.md
+++ b/.claude/commands/create-task.md
@@ -15,7 +15,9 @@ This workflow will:
 1. **Always invoke `grill-with-docs`** to interview the user (no skip — even when the request looks clear)
 2. Read UBIQ + CONTEXT + tech-stack + patterns + ADRs to ground the task in canonical terms
 3. Write a slim `progress-tracker.md` with all missions defined as one-line entries
-4. **Run every mission through the `tdd` skill** (red-green-refactor) — no separate mission docs are created
+4. **Run `critique-plan`** on the drafted missions — a read-only domain critic that pushes back only on genuine conflicts with the domain model (advisory; silent when the plan is sound)
+5. **Run every mission through the `tdd` skill** (red-green-refactor) — no separate mission docs are created
+6. **Run `review-implementation`** after the last mission — three critics (cleaner-architecture, slop-defender, reusability-inspector) on the task diff; interactive here, so findings are presented for you to apply
 
 ## Workflow Details
 - **Always grill** — `grill-with-docs` runs on every invocation

--- a/.claude/commands/extend-task.md
+++ b/.claude/commands/extend-task.md
@@ -16,7 +16,8 @@ This workflow will:
 2. Review current mission progress
 3. Gather requirements for new missions (grills if vague)
 4. Append the new missions as one-line entries in `progress-tracker.md` (no mission docs)
-5. Reopen the task if it was `Completed` — and, if it belongs to a roadmap, reopen its `roadmap.md` entry too (`status: done → pending`) so a `/start-roadmap` re-run picks up the new work in dependency order
+5. **Run `critique-plan` on the new missions** — the pre-implementation domain critic pushes back only on genuine conflicts before you confirm
+6. Reopen the task if it was `Completed` — and, if it belongs to a roadmap, reopen its `roadmap.md` entry too (`status: done → pending`) so a `/start-roadmap` re-run picks up the new work in dependency order
 
 ## Workflow Details
 The extend-task workflow provides:

--- a/.claude/commands/resume-task.md
+++ b/.claude/commands/resume-task.md
@@ -17,6 +17,7 @@ This workflow will:
 3. Load UBIQ + CONTEXT + tech-stack + patterns + ADRs for the next mission
 4. **Run the next mission through the `tdd` skill** (red-green-refactor)
 5. Append a tight technical summary on completion
+6. **Run `review-implementation` after the last mission (interactive)** — three critics (cleaner-architecture, slop-defender, reusability-inspector) on the task diff; findings presented for you to apply before status → Completed
 
 ## Workflow Details
 - The progress tracker carries the mission list and per-mission technical summaries from prior sessions — that's the entire context

--- a/.claude/commands/start-roadmap.md
+++ b/.claude/commands/start-roadmap.md
@@ -22,6 +22,7 @@ It will:
 5. Execute in dependency order; each task runs by `/start-task` rules (subagent per mission, `tdd`, commit per green mission). **Runtime-adaptive shape:** on Claude Code it **nests by default** (task-subagent → mission-subagents) for per-task context isolation; on Codex it stays flat (parent → mission-subagents), since Codex can't nest subagents. Unknown runtime falls back to flat. Update `roadmap.md` statuses as tasks complete.
 
 ## Notes
+- **Post-implementation review per task:** each task runs by `/start-task` rules, so `review-implementation` runs on its diff after the last mission — safe fixes auto-applied, everything written to `docs/tasks/<slug>/review.md`. The critic subagents follow the same nest-on-Claude / flat-on-Codex rule as the mission subagents. The final report lists each task's `review.md` with its open-finding count.
 - Re-runs resume from `roadmap.md` — re-verifies and continues from the frontier.
 - **Incremental / extend case:** after a roadmap completes, use `/extend-task` to add missions to any task (it reopens that task in `roadmap.md`), then re-run `/start-roadmap` — it runs only the tasks that now have unchecked missions, in dependency order, and skips finished ones. A task "needs work" whenever its tracker has an unchecked mission, regardless of its `status:` flag. Common after long PRD-driven builds you want to tweak.
 - Stops loudly on red (never commits broken work), exactly like `/start-task`, one level up.

--- a/.claude/commands/start-task.md
+++ b/.claude/commands/start-task.md
@@ -17,7 +17,8 @@ This workflow will:
 3. Announce the plan (missions, parallel groups, commit-per-mission) and **start immediately** — no "Proceed?"; invoking the command is the consent
 4. **Run every remaining mission in a subagent** through the `tdd` discipline; the subagent checks off its mission and appends its technical summary to the tracker
 5. Verify the test suite after each mission, then **commit** (one commit per mission, one per `[pp-x]` group)
-6. Stop loudly on red — never commits broken work, never starts the next mission on a broken state
+6. **Run `review-implementation` after the last mission (autonomous mode)** — three critics (cleaner-architecture, slop-defender, reusability-inspector) on the task diff; safe fixes auto-applied (tests-green-gated, own commit), everything written to `docs/tasks/<task>/review.md` for you to read afk
+7. Stop loudly on red — never commits broken work, never starts the next mission on a broken state
 
 ## `/start-task` vs `/resume-task`
 - **`/start-task`** — trust the roadmap, walk away, review commits instead of missions

--- a/.claude/skills/critique-plan/SKILL.md
+++ b/.claude/skills/critique-plan/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: critique-plan
+description: Pre-implementation critic. Spins up a read-only domain critic that challenges a drafted plan — a task's missions or a roadmap's task graph — against the ubiquitous language, CONTEXT.md, and ADRs, and pushes back ONLY on genuine conflicts. Silent when the plan is sound. Use before implementing (from create-task / create-roadmap) or standalone to stress-test a plan against the project's domain model.
+---
+
+# Critique Plan (pre-implementation)
+
+Stress-test a **drafted plan** against the project's domain model **before** any code is written. This
+skill produces **pushbacks, not suggestions** — it never gold-plates a plan that is already sound.
+
+> **Silence is the expected outcome.** A plan that speaks the canonical language and respects the
+> documented decisions gets a one-line "No objections." Do not manufacture concerns to look thorough.
+
+**ALWAYS check `.ab-method/structure/index.yaml` FIRST** for where the domain model lives — paths are
+user-configurable.
+
+"The plan" is the drafted **mission list** (from create-task), the **task DAG** (from create-roadmap), or
+whatever the user pastes in (standalone).
+
+## Process
+
+### 1. Load the domain model
+
+Read only what exists; skip missing files silently (don't flag them or offer to create them):
+`UBIQUITOUS_LANGUAGE.md`, `CONTEXT.md` (or `CONTEXT-MAP.md` + each `src/<context>/CONTEXT.md`),
+`docs/adr/`, and `docs/architecture/*`.
+
+### 2. Spin up ONE read-only domain critic (subagent)
+
+Spawn a single subagent — `domain-critic` — with the plan verbatim, the files from Step 1, and the rule
+that it is **read-only**: it returns pushbacks as text and edits nothing. Isolating it keeps the critique
+out of the planning context. Its brief:
+
+**Fire ONLY on a genuine conflict**, one of:
+- **Terminology drift** — the plan names a concept differently from the glossary/`CONTEXT.md`, or reuses
+  a canonical term for a new meaning.
+- **Wrong bounded context** — work placed in the wrong context, or a unit that straddles a documented
+  boundary.
+- **Contradicts an ADR** — reverses a recorded decision *and* the friction is real enough to reopen it.
+  Cite `ADR-NNNN`.
+- **Bad graph seam** (roadmap) — a `depends-on` edge crosses a seam the wrong way, two "independent"
+  tasks share a domain concept, or a task is mis-scoped (an epic, or a single mission dressed as a task).
+- **Reinvents a named concept** — introduces a new abstraction for something the domain model names.
+
+For each, return **What** (the mission/task/decision), **Conflicts with** (the exact term / `CONTEXT.md`
+section / `ADR-NNNN`), **Why it matters** (concrete cost, not taste), **Suggested resolution**.
+
+> Example pushback: *"Mission 3 calls it `archiveOrder`, but the glossary defines archiving as retention
+> only — this mission also stops billing, which is **Cancellation**. Rename to `cancelOrder` so the code
+> matches the domain, or the two concepts will blur across the codebase."*
+
+**Out of scope for this critic:** implementation quality, performance, tests, code style, "you could
+also…" ideas — anything not anchored in the domain model. Those belong to the post-implementation
+[review-implementation](../review-implementation/SKILL.md) skill. With nothing anchored, the critic
+returns exactly: `No objections — the plan is consistent with the domain model.`
+
+### 3. Surface pushbacks — advisory, never blocking
+
+Bring the pushbacks back into the planning session. The user resolves each their way:
+- **Accept** → amend the plan (rename, re-scope, fix the edge, move contexts) right there.
+- **Dismiss** → drop it. If the dismissal rests on a **load-bearing reason** a future planner would need
+  in order not to re-raise it, offer to record an ADR ([../domain-model/ADR-FORMAT.md](../domain-model/ADR-FORMAT.md)).
+  Skip ephemeral ("not now") and self-evident reasons.
+
+When a resolution sharpens a term, update `CONTEXT.md` inline
+([../domain-model/CONTEXT-FORMAT.md](../domain-model/CONTEXT-FORMAT.md)) — same discipline as `/domain-model`.
+
+If the critic returned "No objections," say so in one line and move on. Don't pad it.
+
+`/domain-model` is a full interactive re-grill of the design; `critique-plan` is a **single-pass,
+silent-by-default gate** — one critic, real conflicts only, then straight back to the workflow.

--- a/.claude/skills/review-implementation/ARCHITECTURE.md
+++ b/.claude/skills/review-implementation/ARCHITECTURE.md
@@ -1,0 +1,55 @@
+# Lens: cleaner-architecture
+
+You are the `cleaner-architecture` critic. You review **only this task's diff** for **shallow modules**
+that the change introduced or worsened, and propose **deepening** them. You are read-only: return
+findings, edit nothing.
+
+## Vocabulary — use it exactly
+
+This lens reuses the language already defined for this repo. Read these before you start and use their
+terms (don't drift into "component / service / boundary"):
+
+- [../improve-codebase-architecture/LANGUAGE.md](../improve-codebase-architecture/LANGUAGE.md) —
+  **module, interface, implementation, depth, seam, adapter, leverage, locality**, the **deletion test**.
+- [../improve-codebase-architecture/DEEPENING.md](../improve-codebase-architecture/DEEPENING.md) — how to
+  deepen a cluster safely given its dependency category (in-process / local-substitutable / remote-owned
+  / true-external), and seam discipline (**one adapter = hypothetical seam; two = real**).
+
+Speak the **domain** in `CONTEXT.md` terms and the **architecture** in `LANGUAGE.md` terms — "the Order
+intake module," not "the FooBarHandler."
+
+## What to look for — in the diff only
+
+- **New shallow modules** — a function/class/file the diff added whose interface is nearly as complex as
+  its implementation. Apply the **deletion test**: if you deleted it, would complexity vanish (it was a
+  pass-through) or reappear concentrated across N callers (it earned its keep)? "Vanishes" = shallow.
+- **Pure functions extracted only for testability**, where the real bugs live in *how they're called* —
+  the extraction bought a testable unit but scattered **locality**.
+- **Tight coupling leaking across a seam** the diff created — callers that must know the implementation's
+  internals to use it.
+- **Single-adapter "seams"** — an interface/port the diff introduced with exactly one implementation and
+  no second one in sight. That's indirection, not a seam.
+- **Untested surface** the diff added that is hard to test *through its current interface* — a sign the
+  interface is in the wrong place.
+
+## What NOT to flag
+
+- Pre-existing shallowness the diff didn't touch (that's `/improve-codebase-architecture`'s job, not this
+  review's).
+- Anything an ADR already settled.
+- Depth for depth's sake — if the current shape is already deep enough, say nothing.
+- Style, naming aesthetics, perf — not this lens (naming-as-slop belongs to `slop-defender`).
+
+## Output
+
+For each real finding:
+- **Files** — the modules involved.
+- **Problem** — why it's shallow / where locality or leverage is lost, in `LANGUAGE.md` terms.
+- **Deletion-test result** — vanishes (shallow) vs concentrates (keep).
+- **Suggested deepening** — plain English: what merges behind what interface, what sits at the seam,
+  which dependency category it is (so the tester knows adapter vs stand-in vs direct).
+- **safe-fix vs needs-judgment** — inlining one shallow pass-through into its single caller with tests
+  green is often `safe-fix`; merging several modules behind a new seam is `needs-judgment`.
+
+If the diff introduced no shallowness worth deepening, return exactly:
+`cleaner-architecture: no findings.`

--- a/.claude/skills/review-implementation/REUSE.md
+++ b/.claude/skills/review-implementation/REUSE.md
@@ -1,0 +1,55 @@
+# Lens: reusability-inspector
+
+You are the `reusability-inspector` critic. You catch **reinvention and duplication** in **this task's
+diff** — logic the diff wrote fresh that the codebase already provides, or logic the diff repeats within
+itself. You are read-only: return findings, edit nothing.
+
+Your edge over the other lenses: you must **look outward at the existing codebase**, not just the diff.
+A duplication finding is only credible once you've found the thing being duplicated.
+
+## What to look for
+
+- **Reinvented utilities** — the diff hand-rolls something the repo already has: date formatting,
+  slugify, deep-clone, retry, validation, HTTP wrappers, a money/tax calculation. Search for an existing
+  equivalent before flagging, and name it.
+- **Duplicated domain logic** — the diff re-implements a rule that lives in a canonical module named in
+  `CONTEXT.md` (e.g. a second place that decides when an *Order* is *cancellable*). Domain rules must
+  live in one place.
+- **Ignored existing patterns** — the diff builds a route / component / query in a way that departs from
+  `frontend-patterns.md` / `backend-patterns.md` when a documented pattern (or a near-identical sibling
+  in the codebase) already fits. Point at the sibling.
+- **Internal copy-paste** — the same block repeated across files or missions in the diff, begging to be a
+  shared function or a loop.
+- **Reinvented types** — a new interface/DTO that restates an existing type instead of importing or
+  extending it, risking the two drifting apart.
+
+## How to verify before flagging
+
+1. Grep/search the codebase for the capability (by likely name, by signature shape, by domain term from
+   `CONTEXT.md`).
+2. Confirm the existing thing has **the same semantics**, not just a similar name — a near-match with
+   different edge behavior is *not* a duplication; note that distinction if it's subtle.
+3. Only then report, naming the exact existing module/function/type to reuse.
+
+## What NOT to flag
+
+- "Duplication" where the two pieces have genuinely different semantics or evolve independently (the
+  wrong abstraction is more expensive than a little duplication — say so if you see it being forced).
+- Reuse an ADR explicitly decided against.
+- Trivial two-line similarities that a shared helper would only obscure.
+- Cross-context reuse that would couple two bounded contexts the domain model keeps apart — that coupling
+  is worse than the duplication.
+
+## Output
+
+For each real finding:
+- **Files** — the reinventing code in the diff.
+- **Existing thing to reuse** — exact path + symbol (`src/lib/money.ts → calculateTax`).
+- **Why it matters** — the concrete cost of two copies (they will drift; a fix must be made twice; the
+  domain rule now lives in two places).
+- **Suggested change** — import/extend/call the existing module; or extract the internal copy-paste once.
+- **safe-fix vs needs-judgment** — replacing a fresh copy with a call to an existing util of **identical**
+  semantics, tests green, is `safe-fix`. Anything where the semantics might differ, or that reshapes an
+  interface, is `needs-judgment`.
+
+If the diff reinvented nothing, return exactly: `reusability-inspector: no findings.`

--- a/.claude/skills/review-implementation/SKILL.md
+++ b/.claude/skills/review-implementation/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: review-implementation
+description: Post-implementation review. Spins up three read-only critics on a completed task's diff — cleaner-architecture, slop-defender, reusability-inspector — that push back ONLY on real issues. Autonomous runs apply safe fixes (tests-green-gated) and write everything to review.md next to progress-tracker.md; interactive runs present findings to pick. Use after a task's missions are done (from start-task / start-roadmap / create-task) or standalone on a diff.
+---
+
+# Review Implementation (post-implementation)
+
+Review a **completed task's diff** through three lenses, each a read-only critic subagent. The
+counterpart to [../critique-plan/SKILL.md](../critique-plan/SKILL.md): that guards the plan *before*
+coding; this guards the result *after*.
+
+> **Silence is the default output.** A clean diff produces no findings — that is the normal case. A
+> finding survives only if a senior engineer, looking at this diff, would actually make the change. State
+> each as a concrete cost, not a preference. Never invent refactors to look thorough.
+
+**ALWAYS check `.ab-method/structure/index.yaml` FIRST** for paths (task location, domain model,
+`review.md`). Review **only what this task changed** — the cohesive diff across its missions (`git diff`
+for the commit range). This is not a whole-codebase audit; that's `/improve-codebase-architecture`.
+
+## Process
+
+### 1. Gather diff + context
+
+The changed files and their `git diff`, plus (read only what exists): `UBIQUITOUS_LANGUAGE.md` /
+`CONTEXT.md` (canonical terms, spotting reinvented concepts), `docs/architecture/*` (the documented way
+things are built here), `docs/adr/` (don't propose what an ADR settled).
+
+### 2. Spin up THREE read-only critics — in parallel
+
+Spawn three subagents **in one batch**, named exactly:
+
+| Agent | Lens | Brief |
+|---|---|---|
+| `cleaner-architecture` | depth / deepening | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| `slop-defender` | AI code-slop | [SLOP.md](SLOP.md) |
+| `reusability-inspector` | duplication / reuse | [REUSE.md](REUSE.md) |
+
+Each is **read-only** — analyses the diff, returns a findings list (often empty), edits nothing. Seed
+each with the diff + context + its lens file. On **Codex** (`spawn_agent` is one level deep) spawn them
+at the orchestrator's own level — flat; on **Claude** they may nest. Flat works on both.
+
+### 3. Collect + classify
+
+Merge the lists. Drop anything that's a preference (not a concrete cost), an ADR already settled, or a
+design change bigger than this task (note it open, don't act). Classify each survivor:
+
+- **`safe-fix`** — confirmed, mechanical, **covered by existing tests**, **no interface/behavior change**
+  (delete dead code, inline a pass-through, drop a redundant comment, call an existing util of identical
+  semantics).
+- **`needs-judgment`** — real but design-level, risky, behavior/interface-affecting, or not test-covered.
+
+### 4. Act — by mode
+
+**Interactive** (manual create-task tail, or standalone): present findings grouped by lens, each marked
+`safe-fix`/`needs-judgment`; apply what the user approves; run tests; report.
+
+**Autonomous** (`start-task` / `start-roadmap` — afk): the **orchestrator** (never the parallel critics)
+applies fixes, so there are no concurrent writes:
+1. For each `safe-fix`: apply it, **re-run the test suite** (command from `tech-stack.md`). Green → keep.
+   Red → **revert it**, downgrade to `needs-judgment` with a note (`attempted, reverted — broke <test>`).
+2. Commit kept fixes as one `refactor(<task>): post-review cleanup` (repo convention). Nothing kept → no commit.
+3. **Write `docs/tasks/<task>/review.md`** (below) — every finding, applied or open. Never prompt;
+   anything uncertain stays open rather than being changed.
+
+### 5. `review.md` format
+
+Written next to `progress-tracker.md`. Always write it in autonomous mode — even when clean — so the afk
+user knows the review ran.
+
+```markdown
+# Post-Implementation Review: <Task Name>
+**Reviewed**: YYYY-MM-DD   **Scope**: missions <a–z> / commit <range>
+
+## Applied — safe fixes ✅ (commit <hash>)
+- [slop-defender] removed pass-through wrapper `fooProxy` — src/foo.ts
+- [cleaner-architecture] inlined shallow `formatName` into its one caller — src/user.ts
+
+## Open — need your judgment ⬜
+### [reusability-inspector] duplicates `paymentService.calculateTax`
+- **Files**: src/checkout/tax.ts
+- **Why it matters**: two tax formulas will drift; a rate change must be made twice.
+- **Suggested change**: call the existing `paymentService.calculateTax` instead.
+
+## Clean lenses
+- slop-defender: no further findings
+```
+
+If all three lenses are clean and nothing was applied, the whole body is one line:
+`All three lenses clean — no findings.`

--- a/.claude/skills/review-implementation/SLOP.md
+++ b/.claude/skills/review-implementation/SLOP.md
@@ -1,0 +1,55 @@
+# Lens: slop-defender
+
+You are the `slop-defender` critic. You hunt **AI code-slop** in **this task's diff** — the reflexive
+over-production that models add when left unsupervised: abstraction nothing asked for, ceremony that
+carries no weight, comments that restate the obvious. You are read-only: return findings, edit nothing.
+
+> This is the *code* counterpart of prose "slop." The test for every item below is the **deletion test**
+> (see [../improve-codebase-architecture/LANGUAGE.md](../improve-codebase-architecture/LANGUAGE.md)):
+> delete it — does anything real break, or does the code get simpler and just as correct? If deleting it
+> loses nothing, it's slop.
+
+## The slop checklist — flag only what the diff actually added
+
+- **Speculative generality** — parameters, options, generics, or extension points with exactly one
+  caller and no second one in sight. Built for an imagined future, not the requirement. (YAGNI.)
+- **Premature abstraction** — a base class / interface / factory / strategy introduced for a single
+  concrete case. One implementation is not a seam (echoes the architecture lens; flag whichever fits).
+- **Pass-through wrappers** — a function/method/module that only forwards to another with no added
+  behavior. `getName(u) { return u.name }`, `fooProxy` that calls `foo`.
+- **Dead / unreachable code** — added-but-unused helpers, `if (false)` branches, exports nothing imports,
+  handling for cases the callers can't produce.
+- **Defensive checks for impossible states** — null guards on values the type system already guarantees,
+  try/catch that swallows and rethrows, validation of inputs a caller has already validated.
+- **Comments that restate the code** — `// increment i` above `i++`, docstrings that echo the signature,
+  section-divider banners. Keep comments that explain *why*; cut the ones that narrate *what*.
+- **Needless configuration** — flags, env vars, or config keys with a single value that never varies;
+  "customizable" knobs nothing turns.
+- **Over-verbose naming / ceremony** — `AbstractBaseUserServiceFactoryImpl`, wrapper types that alias a
+  primitive for no invariant, getters/setters over plain fields with no logic.
+- **Redundant tests** — tests asserting the language/framework works, or several tests covering the exact
+  same path with no distinct behavior; and their inverse — a big new surface with **no** test at all.
+- **Copy-pasted boilerplate** the diff duplicated instead of looping/reusing (hand hard duplication to
+  `reusability-inspector`; flag the *ceremony* kind here).
+
+## What NOT to flag
+
+- Slop that predates this diff and wasn't touched.
+- Genuine defensiveness at a real trust boundary (untrusted input, external API, concurrency) — that's
+  not slop, it's necessary.
+- A comment that explains a non-obvious *why*, a hack, or a gotcha — keep it.
+- Anything an ADR blessed.
+- Deep abstractions that already earn their keep across multiple callers.
+
+## Output
+
+For each real finding:
+- **Files + location** — where the slop is.
+- **What kind** — name the checklist item.
+- **Deletion-test result** — what is lost by removing it (nothing = confirmed slop).
+- **Suggested change** — delete / inline / collapse.
+- **safe-fix vs needs-judgment** — deleting dead code, inlining a pure pass-through, or cutting a
+  restate-the-code comment with tests green is usually `safe-fix`. Removing an abstraction other code
+  leans on, or anything you're unsure the tests cover, is `needs-judgment`.
+
+If the diff added no slop, return exactly: `slop-defender: no findings.`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It also installs in every case:
 
 - `.ab-method/` — workflow definitions and the structure index
 - `docs/architecture/` and `docs/tasks/` — output scaffolding
-- Helper skills: `grill-with-docs`, `grill-me`, `tdd`, `domain-model`, `ubiquitous-language`, `improve-codebase-architecture`, `request-refactor-plan`, `to-issues`, `to-prd`, `write-a-skill`
+- Helper skills: `grill-with-docs`, `grill-me`, `tdd`, `domain-model`, `ubiquitous-language`, `critique-plan`, `review-implementation`, `improve-codebase-architecture`, `request-refactor-plan`, `to-issues`, `to-prd`, `write-a-skill`
 - Workflow skills: `ab-create-task`, `ab-create-goal`, `ab-analyze-project`, and one per workflow
 - Slash commands (Claude only): `/ab-master` plus one per workflow
 - `AGENTS.md` (Codex only): orients Codex and lists the workflow skills
@@ -84,8 +84,16 @@ If the runtime can't be determined it falls back to flat, which runs correctly o
 5. Backend-first for full-stack tasks — types feed the frontend.
 6. Never lose a tangent — when a grill surfaces a side-topic that deserves its own task, the `handoff` skill captures it under `docs/handoffs/` instead of derailing the current grill; `/create-task-from-handoff` resumes it later.
 7. Parallel only by consent — independent missions can be tagged `[pp-1]`, `[pp-2]`, ... and run concurrently in subagents; untagged missions are sequential barriers. The workflow always asks before tagging — sequential is the default.
+8. Critique before, review after — `critique-plan` stress-tests the drafted plan against the domain model before coding, and `review-implementation` runs three critics on the diff after. Both push back **only on real issues** — a sound plan or a clean diff produces nothing. No suggestion-for-its-own-sake.
 
 `grill-with-docs` reads `UBIQUITOUS_LANGUAGE.md` and `CONTEXT.md`, challenges terminology against them, and updates `CONTEXT.md` and `docs/adr/` inline as decisions crystallise.
+
+### Pre- and post-implementation analysis
+
+Two critic layers bracket every implementation, both anchored in the domain model and both **opt-in-silent** — they speak only when there is a genuine problem:
+
+- **`critique-plan` (pre-implementation, advisory).** Before missions are validated (in `/create-task`) or the task graph is handed off (in `/create-roadmap`), a read-only domain critic challenges the plan against `UBIQUITOUS_LANGUAGE.md`, `CONTEXT.md`, and `docs/adr/`. It pushes back on genuine conflicts — terminology drift, wrong bounded context, an ADR contradiction, a reinvented concept, a bad seam in the DAG — and stays silent otherwise. You resolve each pushback (amend the plan, or dismiss with a load-bearing reason that may become an ADR).
+- **`review-implementation` (post-implementation).** After a task's missions are done, three read-only critics run in parallel on the task's diff: **cleaner-architecture** (shallow modules the change introduced, via the deletion test), **slop-defender** (AI code-slop — speculative generality, pass-through wrappers, dead code, comments that restate code), and **reusability-inspector** (logic that duplicates an existing util/service/type). Each returns nothing when the diff is clean. In autonomous runs (`/start-task`, `/start-roadmap`) the orchestrator auto-applies only **safe** fixes (mechanical, test-covered, no behavior change — each gated on green tests) and writes **everything** to `docs/tasks/<task>/review.md` next to the tracker: safe fixes marked applied, riskier findings left open for you to read afk. Interactive runs present the findings for you to pick instead.
 
 ## Task vs Goal vs Roadmap
 
@@ -103,7 +111,7 @@ The method is **fractal**: `roadmap → tasks` mirrors `task → missions`. `dep
 
 1. Baseline — `/analyze-project` produces `UBIQUITOUS_LANGUAGE.md`, `CONTEXT.md`, and three lean architecture docs.
 2. Sharpen — the `domain-model` skill grills the domain language and captures ADRs.
-3. Build — `/create-task` or `/create-goal` grills, then either TDD-loops missions or hands off a goal prompt. For multi-task efforts, `/create-roadmap` draws the task graph and `/start-roadmap` runs it in dependency order.
+3. Build — `/create-task` or `/create-goal` grills, `critique-plan` stress-tests the plan against the domain model, then either TDD-loops missions or hands off a goal prompt, and `review-implementation` critiques the resulting diff. For multi-task efforts, `/create-roadmap` draws the task graph and `/start-roadmap` runs it in dependency order.
 4. Maintain — `/update-architecture` keeps the baseline fresh.
 
 ## File layout
@@ -122,6 +130,7 @@ docs/
   architecture/          tech-stack.md, frontend-patterns.md, backend-patterns.md
   adr/                   Decision records, created lazily by /domain-model
   tasks/<task-name>/     progress-tracker.md (single source of truth)
+                         review.md (post-implementation review; autonomous runs)
   goals/<goal-name>/     goal.md + progress-tracker.md
   handoffs/<slug>.md     Tangents spun off mid-grill, awaiting their own task
 ```

--- a/cli.js
+++ b/cli.js
@@ -200,10 +200,14 @@ async function install() {
         '',
         'Principles: always grill before defining work (`grill-with-docs`); every',
         'mission runs through `tdd` (red-green-refactor); `progress-tracker.md` is',
-        'the single source of truth per task. When a tangent surfaces mid-grill that',
-        'deserves its own task, capture it with the `handoff` skill under',
-        '`docs/handoffs/` instead of derailing — resume it later with',
-        '`ab-create-task-from-handoff`.',
+        'the single source of truth per task. Before implementing, `critique-plan`',
+        'stress-tests the drafted plan against the domain model (pushes back only on',
+        'real conflicts). After implementing, `review-implementation` runs three',
+        'critics on the diff (cleaner-architecture, slop-defender, reusability-',
+        'inspector) — autonomous runs apply safe fixes and write `review.md` next to',
+        'the tracker. When a tangent surfaces mid-grill that deserves its own task,',
+        'capture it with the `handoff` skill under `docs/handoffs/` instead of',
+        'derailing — resume it later with `ab-create-task-from-handoff`.',
         '<!-- ab-method:end -->',
         ''
       ].join('\n');


### PR DESCRIPTION
## What

Two domain-model-anchored critic skills that bracket implementation, both **opt-in-silent** — they push back only on real issues, never suggestion-for-its-own-sake.

- **`critique-plan`** (pre-implementation, advisory) — a read-only domain critic that challenges a drafted plan (a task's missions or a roadmap's task graph) against `UBIQUITOUS_LANGUAGE.md`, `CONTEXT.md`, and ADRs. Surfaces genuine conflicts only (terminology drift, wrong context, ADR contradiction, reinvented concept, bad graph seam); silent when the plan is sound.
- **`review-implementation`** (post-implementation) — three read-only critics on the completed task diff: **cleaner-architecture** (shallow modules via the deletion test), **slop-defender** (AI code-slop), **reusability-inspector** (duplicated/reinvented logic). Autonomous runs auto-apply only `safe-fix` findings (tests-green-gated, own commit) and write everything to `review.md` next to `progress-tracker.md`; interactive runs present findings to pick.

## Wiring (symmetric coverage)

| | pre: critique-plan | post: review-implementation |
|---|---|---|
| create-task | ✓ | ✓ |
| create-roadmap (on the DAG) | ✓ | — |
| create-task-from-handoff | ✓ (delegated) | ✓ (delegated) |
| extend-task | ✓ | — |
| start-task | — | ✓ |
| resume-task | — | ✓ |
| start-roadmap (per task) | — | ✓ (inherited) |

Every mission-drafting path gets the pre-critique; every task-completion path gets the post-review.

## Also updated
`index.yaml` (documents `review.md` + both skills), `cli.js` AGENTS.md generator, the 6 command docs, README. Skills mirrored in both `.agents/skills/` and `.claude/skills/`.

## Verification
- CLI install simulated into a scratch project → new skills (with companions) land in both trees, AGENTS.md + core wiring carried through.
- Both `SKILL.md` under 100 lines, frontmatter valid, all cross-reference links resolve, mirrors byte-identical, `index.yaml` no dup keys, `cli.js` syntax OK.

## Release
`feat:` → semantic-release bumps **3.5.0 → 3.6.0** on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)